### PR TITLE
Refresh-ruby-gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.686.0)
+    aws-partitions (1.688.0)
     aws-sdk-core (3.168.4)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,0 @@
-web: bin/rails server -p 3000
-js: yarn build --watch
-css: yarn build:css --watch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flix
 
-The purpose of this project is to implement an application where fans can comment on and rate movies . This application was built as part of the The Pragmatic Studios' Ruby on Rails 6 course exercises. Also, the running application can be found [here](https://flix-cwt.herokuapp.com).
+The purpose of this project is to implement an application where fans can comment on and rate movies. This application was built as part of the The Pragmatic Studios' Ruby on Rails 6 course exercises.
 
 ## Getting Started
 


### PR DESCRIPTION
This PR supports the following features:

- remove support for Heroku

- refresh Ruby gems