### PR TITLE
Update to Rubocop 1..78.0.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.4)
-    rubocop (1.77.0)
+    rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)


### PR DESCRIPTION
This PR supports the following features:

-  update to Rubocop 1..78.0